### PR TITLE
fix planet sort order

### DIFF
--- a/js/functions.js
+++ b/js/functions.js
@@ -637,6 +637,18 @@ function debriesColor(metal, crystal){
 			debriesSum > 0 ? 'lightgreen' : '';
 }
 
+/**
+ * Sort planets using user preferred order
+ * @return planets indexed by sort key instead of planet.id
+ */
+function sortPlanets(planets){
+    var sorted = {};
+    foreach(planets, function(p){
+        sorted[parseInt(100000 * p.g + 100 * p.s + 1 * p.p)] = p;
+    });
+    return sorted;
+}
+
 function officerCheck(){
 	officers = {};
 	if(user['rank'] <= 50 && user['rank'] !='' && user['rank'] != 0){

--- a/js/screens/info.js
+++ b/js/screens/info.js
@@ -298,7 +298,7 @@
 	BuildJumpableMoonCombo: function(){
 		var moons = {};
 		var out = '';
-		foreach(responseObj.state.planets, function(id, v){
+		foreach(sortPlanets(responseObj.state.planets), function(id, v){
 			if(parseInt(v.planet_type) == 3 && v.id != planet.id){
 				var p = responseObj.state.planets[v.id];
 				var RestString = Info.GetNextJumpWaitTime(p);

--- a/js/screens/overview.js
+++ b/js/screens/overview.js
@@ -113,7 +113,7 @@
 
 			var planet_list = '';
 			
-			foreach (responseObj.state.planets, function(k, p){
+			foreach (sortPlanets(responseObj.state.planets), function(k, p){
     			var current = '';
 				if(parseInt(planet.id) == parseInt(p.id)){
 				   current = 'selected="selected"';

--- a/js/screens/planetchooser.js
+++ b/js/screens/planetchooser.js
@@ -28,7 +28,7 @@ var PlanetChooser = {
 		var _planet = planet;
 		var rows = [];
 
-		foreach (responseObj.state.planets, function(k, pl) {
+		foreach (sortPlanets(responseObj.state.planets), function(k, pl) {
 			var planet_id = parseInt(pl.id);
 			var planet_type = parseInt(pl.planet_type);
 

--- a/js/screens/shipyard.js
+++ b/js/screens/shipyard.js
@@ -144,7 +144,7 @@
 				// DO step 2 and 3
 				var own_planets = '';
 				var target_own_planet = undefined;
-				foreach(responseObj.state.planets, function(k,pl){
+				foreach(sortPlanets(responseObj.state.planets), function(k,pl){
 					if(parseInt(pl.id) != parseInt(_planet.id)){
 						own_planets += '<option value="'+pl.g+';'+pl.s+';'+pl.p+';'+pl.planet_type+'">'+pl.name+' ['+pl.g+':'+pl.s+':'+pl.p+']</option>';
 					}


### PR DESCRIPTION
I believe planets should be sorted by their coords not some random.
Especially in mixed planet/moon list in overview combobox.